### PR TITLE
Feat: Wichteln

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,5 +130,5 @@ dmypy.json
 
 # Own
 data.json
-token.txt
 config.ini
+wichteln.txt

--- a/example_config.ini
+++ b/example_config.ini
@@ -4,6 +4,8 @@ token = 1234567890
 [IDs]
 server = 1234567890
 privileged_roles = 1234567890
+voting_role_to_ping = 1234567890
+minecrafter_role = 1234567890
 offer_channel = 1234567890
 voting_channel = 1234567890
-voting_role_to_ping = 1234567890
+

--- a/main.py
+++ b/main.py
@@ -712,6 +712,7 @@ async def wichteln(ctx: dc.CommandContext, aktion: str, kanal: dc.Channel = None
         if not data["wichteln"]["active"]:
             await ctx.send("Es gibt keine aktive Wichtelung.", ephemeral=True)
             return
+        await ctx.defer(ephemeral=True)
         guild: dc.Guild = await ctx.get_guild()
         guild_id = int(guild.id)
         participants = await dc.get(bot, list[dc.Member], parent_id=guild_id, object_ids=data["wichteln"]["participants"])
@@ -738,13 +739,17 @@ async def wichteln(ctx: dc.CommandContext, aktion: str, kanal: dc.Channel = None
                 )
             ]
         )
-        ctx.popup(wichteln_text_modal)
+        await ctx.popup(wichteln_text_modal)
 
 
 @bot.modal("wichteln_text")
 async def wichteln_text_modal(ctx: dc.CommandContext, text: str):
     with open("wichteln.txt", "w") as f:
         f.write(text)
-    await ctx.send("Der Text wurde gespeichert.", ephemeral=True)
+    wichteln_text_preview_embed = dc.Embed(
+        title="Textvorschau",
+        description=text
+    )
+    await ctx.send("Der Text wurde gespeichert.", ephemeral=True, embeds=wichteln_text_preview_embed)
 
 bot.start()

--- a/main.py
+++ b/main.py
@@ -1,8 +1,7 @@
 import configparser as cp
 import json
-from random import randint
-from time import localtime, mktime, strftime, strptime, time, sleep
-from random import shuffle
+from random import randint, shuffle
+from time import localtime, mktime, sleep, strftime, strptime, time
 
 import interactions as dc
 from interactions.ext.get import get
@@ -743,7 +742,7 @@ async def wichteln(ctx: dc.CommandContext, aktion: str, kanal: dc.Channel = None
 
 
 @bot.modal("wichteln_text")
-async def wichteln_text_modal(ctx: dc.CommandContext, text: str):
+async def wichteln_text_response(ctx: dc.CommandContext, text: str):
     with open("wichteln.txt", "w") as f:
         f.write(text)
     text = text.replace("$year$", strftime("%Y"))

--- a/main.py
+++ b/main.py
@@ -746,6 +746,7 @@ async def wichteln(ctx: dc.CommandContext, aktion: str, kanal: dc.Channel = None
 async def wichteln_text_modal(ctx: dc.CommandContext, text: str):
     with open("wichteln.txt", "w") as f:
         f.write(text)
+    text = text.replace("$year$", strftime("%Y"))
     wichteln_text_preview_embed = dc.Embed(
         title="Textvorschau",
         description=text


### PR DESCRIPTION
This PR
--
**Adds:**
- The "Wichteln" feature
  - Start a Wichtelung
    - All users with the MC role will get a random partner
    - They will be send a DM, stating which partner they have
    - A text is posted in the given channel, pinging the Minecrafters
      - The text can have the variable `$year$` to insert the current year
  - End the Wichtelung
    - Every participating Minecrafter is getting a DM, stating that the Wichtelung has ended
  - Edit the text that is posted, directly in DC trough a nice textfield
    - You'll get a preview of it after saving the text 

**ATTENTION:** You have to add the role id of the minecrafter role to the config (value: `minecrafter_role`; see [example_config.ini](https://github.com/FGBxRamel/CommunityHelperBot/pull/17/files#diff-b2b2481abb40ce43d5d168d330ffc3172e348f2b552533ad43f4b84e3f6c48c6))