### PR TITLE
ref!: Config matching commands

### DIFF
--- a/cmds/admin.py
+++ b/cmds/admin.py
@@ -21,7 +21,7 @@ class AdminCommand(i.Extension):
             config = cp.ConfigParser()
             config.read_file(config_file)
             global scope_ids
-            scope_ids = config.get('IDs', 'server').split(',')
+            scope_ids = config.get('General', 'servers').split(',')
             self.shop_categories = config.get('Shops', 'categories').split(',')
             self.shop_categories = [category.strip()
                                     for category in self.shop_categories]

--- a/cmds/offer.py
+++ b/cmds/offer.py
@@ -19,14 +19,9 @@ class OfferCommand(i.Extension):
             config = cp.ConfigParser()
             config.read_file(config_file)
             global scope_ids
-            scope_ids = config.get('IDs', 'server').split(',')
-            self.privileged_roles_ids = [int(id) for id in config.get(
-                'IDs', 'privileged_roles').split(',')]
+            scope_ids = config.get('General', 'servers').split(',')
             self.role_to_ping_id = config.getint(
-                'IDs', 'voting_role_to_ping')
-
-    def user_is_privileged(self, roles: list[int]) -> bool:
-        return any(role in self.privileged_roles_ids for role in roles)
+                'IDs', 'ping_role')
 
     @staticmethod
     def get_identifiers() -> list[str]:
@@ -112,26 +107,15 @@ class OfferCommand(i.Extension):
             )
             await ctx.send_modal(create_modal)
         elif aktion == "delete":
-            priviledged = self.user_is_privileged(ctx.author.roles)
             options = []
-            if not priviledged:
-                for offer in db.get_data("offers", {"user_id": str(ctx.author.id)}, attribute="offer_id, title", fetch_all=True):
-                    options.append(
-                        i.StringSelectOption(
-                            label=offer[0],
-                            value=offer[0],
-                            description=offer[1]
-                        )
+            for offer in db.get_data("offers", {"user_id": str(ctx.author.id)}, attribute="offer_id, title", fetch_all=True):
+                options.append(
+                    i.StringSelectOption(
+                        label=offer[0],
+                        value=offer[0],
+                        description=offer[1]
                     )
-            else:
-                for offer in db.get_data("offers", attribute="offer_id, title", fetch_all=True):
-                    options.append(
-                        i.StringSelectOption(
-                            label=offer[0],
-                            value=offer[0],
-                            description=offer[1]
-                        )
-                    )
+                )
             if len(options) == 0:
                 await ctx.send("Du hast keine Angebote, die du löschen kannst.", ephemeral=True)
                 return

--- a/cmds/offer.py
+++ b/cmds/offer.py
@@ -21,7 +21,7 @@ class OfferCommand(i.Extension):
             global scope_ids
             scope_ids = config.get('General', 'servers').split(',')
             self.role_to_ping_id = config.getint(
-                'IDs', 'ping_role')
+                'Offer', 'ping_role')
 
     @staticmethod
     def get_identifiers() -> list[str]:

--- a/cmds/shop.py
+++ b/cmds/shop.py
@@ -29,7 +29,7 @@ class ShopCommand(i.Extension):
             self.categories_excluded_from_limit = [
                 category.strip() for category in self.categories_excluded_from_limit]
         global scope_ids
-        scope_ids = config.get('IDs', 'server').split(',')
+        scope_ids = config.get('General', 'server').split(',')
         self.transfer_data = {}
 
     def refresh_components(self):

--- a/cmds/shop.py
+++ b/cmds/shop.py
@@ -29,7 +29,7 @@ class ShopCommand(i.Extension):
             self.categories_excluded_from_limit = [
                 category.strip() for category in self.categories_excluded_from_limit]
         global scope_ids
-        scope_ids = config.get('General', 'server').split(',')
+        scope_ids = config.get('General', 'servers').split(',')
         self.transfer_data = {}
 
     def refresh_components(self):

--- a/cmds/voting.py
+++ b/cmds/voting.py
@@ -23,10 +23,8 @@ class VotingCommand(i.Extension):
             config.read_file(config_file)
             global scope_ids
             scope_ids = config.get('IDs', 'server').split(',')
-            self.privileged_roles_ids = [int(id) for id in config.get(
-                'IDs', 'privileged_roles').split(',')]
             self.voting_role_to_ping_id = config.getint(
-                'IDs', 'voting_role_to_ping')
+                'Voting', 'ping_role')
 
     @staticmethod
     def get_identifiers() -> list[int]:
@@ -34,9 +32,6 @@ class VotingCommand(i.Extension):
         cur = con.cursor()
         cur.execute("SELECT voting_id FROM votings")
         return [int(ident[0]) for ident in cur.fetchall()]
-
-    def user_is_privileged(self, roles: list[int]) -> bool:
-        return any(role in self.privileged_roles_ids for role in roles)
 
     @staticmethod
     def evaluate_voting(message: i.Message) -> str:
@@ -122,12 +117,8 @@ class VotingCommand(i.Extension):
             if db.get_data("votings", {"user_id": int(ctx.author.id)}, fetch_all=True) == []:
                 await ctx.send("Es existieren keine Abstimmungen!")
                 return
-            if self.user_is_privileged(ctx.author.roles):
-                votings: list[tuple] = db.get_data(
-                    "votings", attribute="voting_id", fetch_all=True)
-            else:
-                votings: list[tuple] = db.get_data(
-                    "votings", {"user_id": int(ctx.author.id)}, attribute="voting_id", fetch_all=True)
+            votings: list[tuple] = db.get_data(
+                "votings", {"user_id": int(ctx.author.id)}, attribute="voting_id", fetch_all=True)
             for voting_tuple in votings:
                 options.append(
                     i.StringSelectOption(
@@ -166,12 +157,8 @@ class VotingCommand(i.Extension):
             if db.get_data("votings", {"user_id": int(ctx.author.id)}, fetch_all=True) == []:
                 await ctx.send("Es existieren keine Abstimmungen!")
                 return
-            if self.user_is_privileged(ctx.author.roles):
-                votings: list[tuple] = db.get_data(
-                    "votings", attribute="voting_id", fetch_all=True)
-            else:
-                votings: list[tuple] = db.get_data(
-                    "votings", {"user_id": int(ctx.author.id)}, attribute="voting_id", fetch_all=True)
+            votings: list[tuple] = db.get_data(
+                "votings", {"user_id": int(ctx.author.id)}, attribute="voting_id", fetch_all=True)
             for voting_tuple in votings:
                 options.append(
                     i.StringSelectOption(

--- a/cmds/voting.py
+++ b/cmds/voting.py
@@ -22,7 +22,7 @@ class VotingCommand(i.Extension):
             config = cp.ConfigParser()
             config.read_file(config_file)
             global scope_ids
-            scope_ids = config.get('IDs', 'server').split(',')
+            scope_ids = config.get('General', 'servers').split(',')
             self.voting_role_to_ping_id = config.getint(
                 'Voting', 'ping_role')
 

--- a/example_config.ini
+++ b/example_config.ini
@@ -1,14 +1,16 @@
 [General]
-token = 1234567890
+token = <Bot Token>
+servers = <IDs of the servers the bot should function in>
 
-[IDs]
-server = 1234567890
-wichtel_role = 1234567890
-offer_channel = 1234567890
-voting_channel = 1234567890
-voting_role_to_ping = 1234567890
+[Offer]
+offer_channel = <Channel ID>
+ping_role = <Role ID>
+
+[Voting]
+voting_channel = <Channel ID>
+ping_role = <Role ID>
 
 [Shops]
-max_shops_per_person = 3
-categories = General, Food, Weapons, Tools, Armor, Blocks, Miscellaneous, Other
-categories_excluded_from_limit = General, Food, Miscellaneous, Other
+max_shops_per_person = <Integer>
+categories = <General, Food, Weapons, Tools, Armor, Blocks, Miscellaneous, Other>
+categories_excluded_from_limit = <General, Food, Miscellaneous, Other>

--- a/main.py
+++ b/main.py
@@ -13,12 +13,9 @@ with open('config.ini', 'r') as config_file:
     config = cp.ConfigParser()
     config.read_file(config_file)
     TOKEN = config.get('General', 'token')
-    SERVER_IDS = config.get('IDs', 'server').split(',')
-    privileged_roles_ids = [int(id) for id in config.get(
-        'IDs', 'privileged_roles').split(',')]
-    offer_channel_id = config.getint('IDs', 'offer_channel')
-    voting_channel_id = config.getint('IDs', 'voting_channel')
-    voting_role_to_ping_id = config.getint('IDs', 'voting_role_to_ping')
+    SERVER_IDS = config.get('General', 'servers').split(',')
+    offer_channel_id = config.getint('Offer', 'offer_channel')
+    voting_channel_id = config.getint('Voting', 'voting_channel')
 
 
 bot = i.Client(


### PR DESCRIPTION
Makes the config section names match the command names. This is breaking because of the changed names. Closes #49 