### PR TITLE
fix(voting): Message not found

### DIFF
--- a/classes/voting.py
+++ b/classes/voting.py
@@ -91,7 +91,7 @@ class Voting():
         message = await self.channel.fetch_message(self.message_id)
         try:
             await message.delete()
-        except:
+        except AttributeError:
             pass
 
     async def close(self) -> None:

--- a/classes/voting.py
+++ b/classes/voting.py
@@ -89,14 +89,17 @@ class Voting():
         """Deletes the voting from the database and the embed."""
         db.delete_data("votings", {"voting_id": self.id})
         message = await self.channel.fetch_message(self.message_id)
-        await message.delete()
+        try:
+            await message.delete()
+        except:
+            pass
 
     async def close(self) -> None:
         message = await self.channel.fetch_message(self.message_id)
         try:
             tie = await self._is_tie()
         except AttributeError:
-            self.delete()
+            await self.delete()
             return
         if tie:
             ties = await self._get_ties()
@@ -203,7 +206,7 @@ class Voting():
         try:
             reactions = message.reactions
         except AttributeError:
-            self.delete()
+            await self.delete()
             return None
         counts = [reaction.count for reaction in reactions]
         counts.sort(reverse=True)

--- a/classes/voting.py
+++ b/classes/voting.py
@@ -124,7 +124,7 @@ class Voting():
             await voting.create(emotes=ties)
             self.description += "\n\n**Ergebnis:** Unentschieden! Bitte schaue weiter unten nach."
         else:
-            if tie == None:
+            if tie is None:
                 return
             winner, winner_count = "", 0
             for reaction in message.reactions:

--- a/classes/voting.py
+++ b/classes/voting.py
@@ -92,7 +92,12 @@ class Voting():
         await message.delete()
 
     async def close(self) -> None:
-        message = await self.channel.fetch_message(self.message_id)
+        try:
+            message = await self.channel.fetch_message(self.message_id)
+        except Exception as e:
+            if "404" in str(e):
+                self.delete()
+                return
         tie = await self._is_tie()
         if tie:
             ties = await self._get_ties()
@@ -117,6 +122,8 @@ class Voting():
             await voting.create(emotes=ties)
             self.description += "\n\n**Ergebnis:** Unentschieden! Bitte schaue weiter unten nach."
         else:
+            if tie == None:
+                return
             winner, winner_count = "", 0
             for reaction in message.reactions:
                 if reaction.count > winner_count:
@@ -193,7 +200,12 @@ class Voting():
                       self.wait_time, self.create_time, self.time_type))
 
     async def _is_tie(self) -> bool:
-        message = await self.channel.fetch_message(self.message_id)
+        try:
+            message = await self.channel.fetch_message(self.message_id)
+        except Exception as e:
+            if "404" in str(e):
+                self.delete()
+                return None
         reactions = message.reactions
         counts = [reaction.count for reaction in reactions]
         counts.sort(reverse=True)

--- a/classes/voting.py
+++ b/classes/voting.py
@@ -92,13 +92,12 @@ class Voting():
         await message.delete()
 
     async def close(self) -> None:
+        message = await self.channel.fetch_message(self.message_id)
         try:
-            message = await self.channel.fetch_message(self.message_id)
-        except Exception as e:
-            if "404" in str(e):
-                self.delete()
-                return
-        tie = await self._is_tie()
+            tie = await self._is_tie()
+        except AttributeError:
+            self.delete()
+            return
         if tie:
             ties = await self._get_ties()
             identifier = randint(1000, 9999)
@@ -200,13 +199,12 @@ class Voting():
                       self.wait_time, self.create_time, self.time_type))
 
     async def _is_tie(self) -> bool:
+        message = await self.channel.fetch_message(self.message_id)
         try:
-            message = await self.channel.fetch_message(self.message_id)
-        except Exception as e:
-            if "404" in str(e):
-                self.delete()
-                return None
-        reactions = message.reactions
+            reactions = message.reactions
+        except AttributeError:
+            self.delete()
+            return None
         counts = [reaction.count for reaction in reactions]
         counts.sort(reverse=True)
         tie = not counts[0] != counts[1]


### PR DESCRIPTION
There always was an error when the message was not found. I suppose this is because of human error (deleting message). When the bot doesn't find the message, it will just delete it now.
